### PR TITLE
Add status dashboard for API key quotas

### DIFF
--- a/config/api_keys.json
+++ b/config/api_keys.json
@@ -1,0 +1,4 @@
+{
+    "service1": "API_KEY_FOR_SERVICE1",
+    "service2": "API_KEY_FOR_SERVICE2"
+}

--- a/config/quota_metadata.json
+++ b/config/quota_metadata.json
@@ -1,0 +1,4 @@
+{
+    "service1": {"used": 10, "limit": 1000},
+    "service2": {"used": 50, "limit": 500}
+}

--- a/monitor/status_dashboard.py
+++ b/monitor/status_dashboard.py
@@ -1,0 +1,43 @@
+"""Status dashboard for API keys and quotas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tabulate import tabulate
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CONFIG_DIR = BASE_DIR / "config"
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> None:
+    """Load API keys and quota metadata then print a table."""
+    api_keys_path = CONFIG_DIR / "api_keys.json"
+    quota_path = CONFIG_DIR / "quota_metadata.json"
+
+    api_keys = _load_json(api_keys_path)
+    quota_meta = _load_json(quota_path)
+
+    rows = []
+    for service, key in api_keys.items():
+        quota = quota_meta.get(service, {})
+        rows.append(
+            [
+                service,
+                key,
+                quota.get("used", "N/A"),
+                quota.get("limit", "N/A"),
+            ]
+        )
+
+    print(tabulate(rows, headers=["Service", "API Key", "Used", "Limit"]))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add monitor.status_dashboard for viewing API key quota usage
- store sample API key and quota metadata in config files

## Testing
- `python -m monitor.status_dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68b5f916cf34832eb8e0198b7c7dd139