### PR TITLE
Add drug interaction service and CLI

### DIFF
--- a/drug-interactions
+++ b/drug-interactions
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""CLI for checking drug interactions using the FDA API."""
+import argparse
+from services.drug_interactions import check_interaction
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="drug-interactions",
+        description="Check potential interactions between two drugs using the FDA API",
+    )
+    parser.add_argument("drug1", help="Name of the first drug")
+    parser.add_argument("drug2", help="Name of the second drug")
+    args = parser.parse_args()
+
+    result = check_interaction(args.drug1, args.drug2)
+    if result["interaction"]:
+        print(f"Possible interaction found: {result['details']}")
+    else:
+        print(result["details"])
+
+
+if __name__ == "__main__":
+    main()

--- a/services/drug_interactions.py
+++ b/services/drug_interactions.py
@@ -1,0 +1,42 @@
+import requests
+
+FDA_API_URL = "https://api.fda.gov/drug/label.json"
+
+
+def check_interaction(drug1: str, drug2: str) -> dict:
+    """Check for potential interactions between two drugs using the FDA API.
+
+    Parameters
+    ----------
+    drug1 : str
+        Name of the first drug.
+    drug2 : str
+        Name of the second drug.
+
+    Returns
+    -------
+    dict
+        Dictionary containing keys:
+        - "interaction" (bool): True if an interaction is found.
+        - "details" (str): Description of interaction or reason for failure.
+    """
+    params = {
+        "search": f'openfda.generic_name:"{drug1}"+AND+drug_interactions:"{drug2}"',
+        "limit": 1,
+    }
+
+    try:
+        response = requests.get(FDA_API_URL, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        return {"interaction": False, "details": f"API request failed: {exc}"}
+
+    data = response.json()
+    results = data.get("results") or []
+    if not results:
+        return {"interaction": False, "details": "No interaction data found."}
+
+    interactions = results[0].get("drug_interactions", [])
+    if interactions:
+        return {"interaction": True, "details": interactions[0]}
+    return {"interaction": True, "details": "Interaction found but no details provided."}


### PR DESCRIPTION
## Summary
- add service to query FDA for potential drug interactions
- provide `drug-interactions` CLI for checking two drugs

## Testing
- `pip install requests`
- `./drug-interactions aspirin warfarin` (fails: API request failed: HTTPSConnectionPool(host='api.fda.gov', port=443): Max retries exceeded with url: /drug/label.json?search=openfda.generic_name%3A%22aspirin%22%2BAND%2Bdrug_interactions%3A%22warfarin%22&limit=1 (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))

------
https://chatgpt.com/codex/tasks/task_e_68b5f5766c00832eb1ac4cf262c3de4b